### PR TITLE
Make hostname dynamic

### DIFF
--- a/src/endpoints/xml.ts
+++ b/src/endpoints/xml.ts
@@ -25,7 +25,9 @@ export const sitemapXML = (pluginConfig: SitemapPluginConfig): PayloadHandler =>
 				errorHandler: (error: Error, level: ErrorLevel) => {
 					logger.error(`Error generating sitemap:  ${error}, level: ${level}`);
 				},
-				hostname: pluginConfig.hostname,
+				hostname: typeof pluginConfig.hostname === 'function'
+					? await pluginConfig.hostname(req)
+					: pluginConfig.hostname,
 			});
 			items.forEach((item) => stream.write(item));
 			stream.end();

--- a/src/sitemap/generate.ts
+++ b/src/sitemap/generate.ts
@@ -43,7 +43,9 @@ export const generate = async (args: GenerateConfig): Promise<SitemapRecord[]> =
 		records.push({
 			changeFreq: 'weekly',
 			priority: 1.0,
-			url: config.hostname,
+			url: typeof config.hostname === 'function'
+				? await config.hostname(req)
+				: config.hostname,
 		});
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,7 +87,7 @@ export type SitemapPluginConfig = {
    * The base URL used for generating absolute sitemap URLs.
    * This is required.
    */
-  hostname: string
+  hostname: ((req: PayloadRequest) => Promise<string> | string) | string
 
   /**
    * If set to `true`, drafts will be included in the sitemap.


### PR DESCRIPTION
Change plugin config options from:

```ts
  hostname: string
```

to:
```ts
  hostname: ((req: PayloadRequest) => Promise<string> | string) | string
```

This allows you to supply a function to use hostname based on request:

```ts
  hostname: (req) => req.headers.get('host')
```