### PR TITLE
Fix changefreq and lastmod not being added to sitemap

### DIFF
--- a/src/endpoints/xml.ts
+++ b/src/endpoints/xml.ts
@@ -1,5 +1,5 @@
 import type { PayloadHandler, PayloadRequest } from 'payload';
-import type { ErrorLevel } from 'sitemap/dist/lib/types.js';
+import type { EnumChangefreq, ErrorLevel, SitemapItemLoose } from 'sitemap/dist/lib/types.js';
 
 import { SitemapStream, streamToPromise } from 'sitemap';
 
@@ -16,6 +16,12 @@ export const sitemapXML = (pluginConfig: SitemapPluginConfig): PayloadHandler =>
 			req,
 			useCache: true,
 		});
+		const sitemapItems: SitemapItemLoose[] = items.map((item) => ({
+			changefreq: item.changeFreq as EnumChangefreq,
+			lastmod: item.lastModified,
+			priority: item.priority,
+			url: item.url,
+		}));
 
 		/**
 		 * Generate the sitemap and return the response to the writer.
@@ -29,7 +35,7 @@ export const sitemapXML = (pluginConfig: SitemapPluginConfig): PayloadHandler =>
 					? await pluginConfig.hostname(req)
 					: pluginConfig.hostname,
 			});
-			items.forEach((item) => stream.write(item));
+			sitemapItems.forEach((item) => stream.write(item));
 			stream.end();
 
 			const xmlData = await streamToPromise(stream);

--- a/src/sitemap/generate.ts
+++ b/src/sitemap/generate.ts
@@ -6,7 +6,7 @@ import { SitemapCache } from './cache.js';
 
 export type SitemapRecord = {
 	changeFreq?: ChangeFrequency
-	lastModified?: Date
+	lastModified?: string
 	priority?: SitemapPriority
 	url: string
 }
@@ -56,7 +56,7 @@ export const generate = async (args: GenerateConfig): Promise<SitemapRecord[]> =
 		for (const route of config.customRoutes) {
 			records.push({
 				changeFreq: route.changeFreq,
-				lastModified: route.lastMod ? route.lastMod : undefined,
+				lastModified: route.lastMod ? route.lastMod.toISOString() : undefined,
 				priority: route.priority,
 				url: route.loc,
 			});
@@ -120,9 +120,9 @@ export const generate = async (args: GenerateConfig): Promise<SitemapRecord[]> =
 				// Get last modified date
 				let lastModified = undefined;
 				if (collectionConfig.lastModField && doc[collectionConfig.lastModField]) {
-					lastModified = new Date(doc[collectionConfig.lastModField]);
+					lastModified = doc[collectionConfig.lastModField];
 				} else if (doc.updatedAt) {
-					lastModified = new Date(doc.updatedAt);
+					lastModified = doc.updatedAt;
 				}
 
 				// Call the user defined generate URL function.


### PR DESCRIPTION
Change item key names:
- `lastModified` -> `lastmod`
- `changeFreq` -> `changefreq`

Since the `sitemap` npm package does not recognise the old item keys and wouldn't add them to the xml file.

Also changed `lastModified` type to be string rather than Date since cache.get would return it as a string rather than a Date.