### PR TITLE
Add option to disable regenerate endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ Visit the [documentation](https://payloadcms.com/docs/jobs-queue/queues#executin
 
 ## Endpoints
 
-| Endpoint                                | Description                         | Method |
-|-----------------------------------------|-------------------------------------|--------|
-| `/api/plugin-sitemap/sitemap/index.xml` | The generated sitemap XML file.     | `GET`  |
-| `/api/plugin-sitemap/regenerate`        | Endpoint to regenerate the sitemap. | `POST` |
+| Endpoint                                | Description                                                                                                                      | Method |
+|-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|--------|
+| `/api/plugin-sitemap/sitemap/index.xml` | The generated sitemap XML file.                                                                                                  | `GET`  |
+| `/api/plugin-sitemap/regenerate`        | Endpoint to regenerate the sitemap. Disable the endpoint with `disableRegenerate` or use middleware to prevent unauthorized use. | `POST` |
 
 ## Config
 
@@ -123,6 +123,7 @@ Visit the [documentation](https://payloadcms.com/docs/jobs-queue/queues#executin
 | `customRoutes`                    | -               | Custom routes to include in the sitemap with their own configuration (change frequency, last modified date, priority).                                |
 | `defaultPriority`                 | `0.5`           | Default priority for all documents in the sitemap. Values range from 0.0 (lowest) to 1.0 (highest).                                                   |
 | `disabled`                        | `false`         | If set to `true`, disables the sitemap plugin.                                                                                                        |
+| `disableRegenerate`               | `false`         | Disable the regenerate endpoint when set to `true`.                                                                                                   |  
 | `generateURL`                     | -               | Custom function to generate URLs for documents in this collection.                                                                                    |
 | `includeDrafts`                   | `false`         | If `true`, includes drafts in the sitemap. This is overridden by individual collection settings.                                                      |
 | `includeHomepage`                 | `true`          | If `true`, includes a default `/` entry in the sitemap.                                                                                               |

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,12 +49,15 @@ export const sitemapPlugin = (pluginConfig: SitemapPluginConfig) => (config: Con
 			method: 'get',
 			path: '/plugin-sitemap/sitemap/index.xml',
 		},
-		{
+	];
+
+	if (!pluginConfig.disableRegenerate) {
+		config.endpoints.push({
 			handler: regenerate(pluginConfig),
 			method: 'post',
 			path: '/plugin-sitemap/regenerate',
-		},
-	];
+		});
+	}
 
 	return config;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,13 @@ export type SitemapPluginConfig = {
   disabled?: boolean
 
   /**
+   * Disable the regenerate endpoint to prevent unauthorized access.
+   *
+   * @default false
+   */
+  disableRegenerate?: boolean
+
+  /**
    * Custom function to generate URLs for documents in this collection.
    * If not provided, a default URL structure will be used.
    */


### PR DESCRIPTION
The regenerate endpoint can generate quite a bit of server load so this patch adds an option to prevent unauthorized access. It is a bit of a quick and dirty solution. An other way to handle this could be to add access hooks to the endpoints like payload collections. I can work on this if that's the preferred way to to it.