### PR TITLE
refactor: Don't pass all fields in to overrides

### DIFF
--- a/dev/int.spec.ts
+++ b/dev/int.spec.ts
@@ -112,7 +112,7 @@ describe('Plugin tests', () => {
 		expect(exists).toBe(true);
 	});
 
-	it('applies access control to default sitemap fields', () => {
+	it('hides default sitemap fields in admin', () => {
 		const fields = payload.collections['posts'].config.fields as FieldBase[];
 
 		const sitemapFields = ['sitemapPriority', 'excludeFromSitemap'];
@@ -120,8 +120,8 @@ describe('Plugin tests', () => {
 		sitemapFields.forEach(fieldName => {
 			const field = fields.find(f => f.name === fieldName);
 			expect(field).toBeDefined();
-			expect(field?.access).toBeDefined();
-			expect(typeof field?.access?.read).toBe('function');
+			expect(field?.admin).toBeDefined();
+			expect(field?.admin?.hidden).toBe(true);
 		});
 	});
 });

--- a/dev/int.spec.ts
+++ b/dev/int.spec.ts
@@ -111,5 +111,18 @@ describe('Plugin tests', () => {
 		const exists = globalFields.some((f) => f.name === 'extraSetting');
 		expect(exists).toBe(true);
 	});
+
+	it('applies access control to default sitemap fields', () => {
+		const fields = payload.collections['posts'].config.fields as FieldBase[];
+
+		const sitemapFields = ['sitemapPriority', 'excludeFromSitemap'];
+
+		sitemapFields.forEach(fieldName => {
+			const field = fields.find(f => f.name === fieldName);
+			expect(field).toBeDefined();
+			expect(field?.access).toBeDefined();
+			expect(typeof field?.access?.read).toBe('function');
+		});
+	});
 });
 

--- a/dev/payload.config.ts
+++ b/dev/payload.config.ts
@@ -1,7 +1,7 @@
 import { mongooseAdapter } from '@payloadcms/db-mongodb';
 import { lexicalEditor } from '@payloadcms/richtext-lexical';
 import path from 'path';
-import { buildConfig } from 'payload';
+import { buildConfig, Field } from 'payload';
 import sharp from 'sharp';
 import { fileURLToPath } from 'url';
 
@@ -59,7 +59,10 @@ export default buildConfig({
 			collections: {
 				posts: {
 					fieldOverrides: ({ defaultFields }) => [
-						...defaultFields,
+						...defaultFields.map(f => ({
+							...f,
+							hidden: true,
+						})) as Field[],
 						{
 							name: 'customSEO',
 							type: 'text',

--- a/dev/payload.config.ts
+++ b/dev/payload.config.ts
@@ -61,7 +61,7 @@ export default buildConfig({
 					fieldOverrides: ({ defaultFields }) => [
 						...defaultFields.map(f => ({
 							...f,
-							hidden: true,
+							admin: { ...(f.admin || {}), hidden: true },
 						})) as Field[],
 						{
 							name: 'customSEO',

--- a/dev/payload.config.ts
+++ b/dev/payload.config.ts
@@ -59,10 +59,12 @@ export default buildConfig({
 			collections: {
 				posts: {
 					fieldOverrides: ({ defaultFields }) => [
+						// Make all fields hidden in the UI for testing field overrides.
 						...defaultFields.map(f => ({
 							...f,
 							admin: { ...(f.admin || {}), hidden: true },
 						})) as Field[],
+						// Add a random field in to assert that one exists.
 						{
 							name: 'customSEO',
 							type: 'text',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "payload-sitemap-plugin",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"description": "Payload Sitemap Plugin",
 	"license": "MIT",
 	"type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,20 +51,18 @@ export const sitemapPlugin = (pluginConfig: SitemapPluginConfig) => (config: Con
 			}
 
 			let defaultFields: Field[] = [
-				...(collection.fields || []),
 				SitemapPriority,
 				ExcludeFromSitemap,
 			];
 
-			// Apply per-collection field overrides if provided,
+			// Apply per-collection field overrides if provided.
 			const collConfig = pluginConfig.collections[collectionSlug];
 			if (typeof collConfig !== 'boolean' && collConfig?.fieldOverrides) {
-				defaultFields = collConfig.fieldOverrides({
-					defaultFields,
-				});
+				defaultFields = collConfig.fieldOverrides({ defaultFields });
 			}
 
-			collection.fields = defaultFields;
+			// Merge the sitemap fields into the collection without overwriting other fields.
+			collection.fields = [...(collection.fields || []), ...defaultFields];
 		}
 	}
 


### PR DESCRIPTION
At the moment we pass in all fields for the collection, this PR only passes in ones thats created by the plugin.